### PR TITLE
Switch to IMDb Swagger search endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ accordingly.
 ## Requirements
 
 * Python 3.10+
-* An imdbapi.dev API key
 
 ## Installation
 
@@ -18,7 +17,6 @@ pip install -e .
 ## Usage
 
 ```bash
-export IMDB_API_KEY="your-api-key"
 # Dry run (default):
 db /path/to/movies
 
@@ -35,7 +33,6 @@ leaves the file untouched.
 Prefer a windowed interface? Launch the experimental Tkinter application:
 
 ```bash
-export IMDB_API_KEY="your-api-key"
 db-gui
 ```
 

--- a/deebee/cli.py
+++ b/deebee/cli.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import argparse
-import os
 from pathlib import Path
 
 from rich.console import Console
@@ -16,14 +15,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "path",
         nargs="?",
-        default=os.getcwd(),
+        default=str(Path.cwd()),
         help="Directory containing movie files to process",
-    )
-    parser.add_argument(
-        "--api-key",
-        dest="api_key",
-        default=os.environ.get("IMDB_API_KEY"),
-        help="API key for imdbapi.dev (defaults to IMDB_API_KEY env var)",
     )
     parser.add_argument(
         "--execute",
@@ -44,11 +37,8 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    if not args.api_key:
-        parser.error("An API key is required. Set --api-key or IMDB_API_KEY environment variable.")
-
     console = Console()
-    imdb_client = IMDBClient(args.api_key)
+    imdb_client = IMDBClient()
     renamer = MovieRenamer(imdb_client, console)
 
     directory = Path(args.path)

--- a/deebee/gui.py
+++ b/deebee/gui.py
@@ -1,7 +1,7 @@
 """Basic Tkinter-based graphical interface for DeeBee."""
+
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from typing import Callable, List, Optional
 
@@ -115,7 +115,6 @@ class DeeBeeApp:
         root.title("DeeBee")
         root.geometry("600x400")
 
-        self._api_key_var = tk.StringVar(value=os.environ.get("IMDB_API_KEY", ""))
         self._path_var = tk.StringVar(value=str(Path.cwd()))
         self._limit_var = tk.IntVar(value=10)
         self._dry_run_var = tk.BooleanVar(value=True)
@@ -126,36 +125,32 @@ class DeeBeeApp:
         main_frame = ttk.Frame(self._root, padding=10)
         main_frame.pack(fill=tk.BOTH, expand=True)
 
-        ttk.Label(main_frame, text="IMDB API Key:").grid(row=0, column=0, sticky=tk.W)
-        api_entry = ttk.Entry(main_frame, textvariable=self._api_key_var, width=40)
-        api_entry.grid(row=0, column=1, columnspan=2, sticky=tk.EW, pady=2)
-
-        ttk.Label(main_frame, text="Directory:").grid(row=1, column=0, sticky=tk.W)
+        ttk.Label(main_frame, text="Directory:").grid(row=0, column=0, sticky=tk.W)
         path_entry = ttk.Entry(main_frame, textvariable=self._path_var, width=40)
-        path_entry.grid(row=1, column=1, sticky=tk.EW, pady=2)
-        ttk.Button(main_frame, text="Browse", command=self._choose_directory).grid(row=1, column=2, padx=(5, 0))
+        path_entry.grid(row=0, column=1, sticky=tk.EW, pady=2)
+        ttk.Button(main_frame, text="Browse", command=self._choose_directory).grid(row=0, column=2, padx=(5, 0))
 
-        ttk.Label(main_frame, text="Result limit:").grid(row=2, column=0, sticky=tk.W)
+        ttk.Label(main_frame, text="Result limit:").grid(row=1, column=0, sticky=tk.W)
         limit_spin = ttk.Spinbox(main_frame, from_=1, to=50, textvariable=self._limit_var, width=5)
-        limit_spin.grid(row=2, column=1, sticky=tk.W, pady=2)
+        limit_spin.grid(row=1, column=1, sticky=tk.W, pady=2)
 
         dry_run_check = ttk.Checkbutton(main_frame, text="Dry run (no changes)", variable=self._dry_run_var)
-        dry_run_check.grid(row=2, column=2, sticky=tk.W)
+        dry_run_check.grid(row=1, column=2, sticky=tk.W)
 
         self._log_widget = tk.Text(main_frame, height=12, state=tk.DISABLED)
-        self._log_widget.grid(row=3, column=0, columnspan=3, sticky=tk.NSEW, pady=(10, 0))
+        self._log_widget.grid(row=2, column=0, columnspan=3, sticky=tk.NSEW, pady=(10, 0))
 
         scrollbar = ttk.Scrollbar(main_frame, command=self._log_widget.yview)
-        scrollbar.grid(row=3, column=3, sticky=tk.NS)
+        scrollbar.grid(row=2, column=3, sticky=tk.NS)
         self._log_widget.configure(yscrollcommand=scrollbar.set)
 
         button_frame = ttk.Frame(main_frame)
-        button_frame.grid(row=4, column=0, columnspan=3, pady=10)
+        button_frame.grid(row=3, column=0, columnspan=3, pady=10)
 
         ttk.Button(button_frame, text="Start", command=self._start_processing).pack(side=tk.LEFT, padx=5)
 
         main_frame.columnconfigure(1, weight=1)
-        main_frame.rowconfigure(3, weight=1)
+        main_frame.rowconfigure(2, weight=1)
 
     def _choose_directory(self) -> None:
         directory = filedialog.askdirectory(initialdir=self._path_var.get() or None)
@@ -171,11 +166,6 @@ class DeeBeeApp:
 
     def _start_processing(self) -> None:
         directory = Path(self._path_var.get()).expanduser()
-        api_key = self._api_key_var.get().strip()
-
-        if not api_key:
-            messagebox.showerror("Missing API key", "Please provide an imdbapi.dev API key.")
-            return
 
         if not directory.exists() or not directory.is_dir():
             messagebox.showerror("Invalid directory", f"{directory} is not a valid directory.")
@@ -188,7 +178,7 @@ class DeeBeeApp:
             return
 
         self._append_log(f"Starting scan in {directory}...")
-        imdb_client = IMDBClient(api_key)
+        imdb_client = IMDBClient()
         renamer = GUIMovieRenamer(imdb_client, self._root, self._append_log)
 
         try:

--- a/deebee/imdb_client.py
+++ b/deebee/imdb_client.py
@@ -23,10 +23,25 @@ class IMDBMovie:
 
     @classmethod
     def from_dict(cls, payload: dict) -> "IMDBMovie":
+        title = (
+            payload.get("primaryTitle")
+            or payload.get("originalTitle")
+            or (payload.get("titleText") or {}).get("text")
+            or payload.get("title", "")
+        )
+
+        year_value = (
+            payload.get("startYear")
+            or (payload.get("releaseYear") or {}).get("year")
+            or (payload.get("titleYear") or {}).get("year")
+            or payload.get("year")
+        )
+        year = str(year_value) if year_value else None
+
         return cls(
             id=payload.get("id", ""),
-            title=payload.get("title", ""),
-            year=payload.get("year"),
+            title=title,
+            year=year,
         )
 
     def display_text(self) -> str:
@@ -38,13 +53,34 @@ class IMDBMovie:
 class IMDBClient:
     """HTTP client wrapper for imdbapi.dev searches."""
 
-    def __init__(self, api_key: str, *, session: Optional["requests.Session"] = None) -> None:
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        *,
+        session: Optional["requests.Session"] = None,
+        base_url: str = "https://api.imdbapi.dev",
+    ) -> None:
+        """Create a new client.
+
+        Parameters
+        ----------
+        api_key:
+            Deprecated parameter retained for backward compatibility. The new
+            search endpoint does not require authentication, so the value is
+            ignored when provided.
+        session:
+            Optional custom :class:`requests.Session` instance, primarily used
+            for testing.
+        base_url:
+            Base URL for the imdbapi.dev service.
+        """
+
         if requests is None:  # pragma: no cover - exercised in runtime environments without dependency
             raise RuntimeError("The 'requests' package is required to use IMDBClient.")
 
-        self._api_key = api_key
         self._session = session or requests.Session()
-        self._base_url = "https://imdbapi.dev/api"
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
 
     def search(self, query: str, *, limit: int = 10) -> List[IMDBMovie]:
         """Search for a movie title using the imdbapi.dev title endpoint."""
@@ -52,12 +88,12 @@ class IMDBClient:
         if not query.strip():
             return []
 
-        params = {"search": query, "limit": limit}
-        response = self._session.get(
-            f"{self._base_url}/search", params=params, headers={"Authorization": f"Bearer {self._api_key}"}
-        )
+        params = {"query": query, "limit": min(max(limit, 1), 50)}
+
+        headers = {"Authorization": f"Bearer {self._api_key}"} if self._api_key else None
+        response = self._session.get(f"{self._base_url}/search/titles", params=params, headers=headers)
         response.raise_for_status()
         payload = response.json()
 
-        results: Iterable[dict] = payload.get("results", [])
+        results: Iterable[dict] = payload.get("titles") or payload.get("results", [])
         return [IMDBMovie.from_dict(item) for item in results]


### PR DESCRIPTION
## Summary
- update the IMDb client to use the `/search/titles` endpoint from the Swagger definition and parse modern title fields
- drop the API key requirement from the CLI and GUI while keeping defaults compatible
- refresh the README to reflect the simplified setup

## Testing
- pytest

------
