### PR TITLE
Add configurable filename formats for movie renaming

### DIFF
--- a/deebee/cli.py
+++ b/deebee/cli.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from rich.console import Console
 
 from .imdb_client import IMDBClient
-from .renamer import MovieRenamer
+from .renamer import DEFAULT_RENAME_FORMAT_KEY, MovieRenamer
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -30,6 +30,15 @@ def build_parser() -> argparse.ArgumentParser:
         default=10,
         help="Maximum number of IMDB results to present",
     )
+    formats = MovieRenamer.available_formats()
+    format_descriptions = ", ".join(f"{spec.key}: {spec.label}" for spec in formats)
+    parser.add_argument(
+        "--format",
+        dest="rename_format",
+        choices=[spec.key for spec in formats],
+        default=DEFAULT_RENAME_FORMAT_KEY,
+        help=f"Filename format to use. Available options: {format_descriptions}",
+    )
     return parser
 
 
@@ -39,7 +48,11 @@ def main(argv: list[str] | None = None) -> int:
 
     console = Console()
     imdb_client = IMDBClient()
-    renamer = MovieRenamer(imdb_client, console)
+    renamer = MovieRenamer(
+        imdb_client,
+        console,
+        rename_format=args.rename_format,
+    )
 
     directory = Path(args.path)
     if not directory.exists() or not directory.is_dir():

--- a/tests/test_renamer.py
+++ b/tests/test_renamer.py
@@ -4,7 +4,7 @@ from typing import List
 import pytest
 
 from deebee.imdb_client import IMDBMovie
-from deebee.renamer import MovieRenamer
+from deebee.renamer import DEFAULT_RENAME_FORMAT_KEY, MovieRenamer
 
 
 class DummyConsole:
@@ -59,3 +59,36 @@ def test_process_directory_dry_run(movie: Path) -> None:
     assert candidate.proposed_filename == "The Matrix (1999).mkv"
     # Ensure dry run did not rename the file.
     assert movie.exists()
+
+
+@pytest.mark.parametrize(
+    "format_key,expected",
+    [
+        (DEFAULT_RENAME_FORMAT_KEY, "The Matrix (1999).mkv"),
+        ("title_dash_year", "The Matrix - 1999.mkv"),
+        ("year_dash_title", "1999 - The Matrix.mkv"),
+        ("title_only", "The Matrix.mkv"),
+        ("title_brackets_year", "The Matrix [1999].mkv"),
+    ],
+)
+def test_process_directory_custom_formats(movie: Path, format_key: str, expected: str) -> None:
+    movie_info = IMDBMovie(id="tt0133093", title="The Matrix", year="1999")
+    client = DummyClient([movie_info])
+    renamer = MovieRenamer(client, console=DummyConsole(["1"]), rename_format=format_key)
+
+    directory = movie.parent
+    results = renamer.process_directory(directory, dry_run=True, search_limit=5)
+
+    assert len(results) == 1
+    assert results[0].proposed_filename == expected
+
+
+def test_missing_year_uses_title_only(movie: Path) -> None:
+    movie_info = IMDBMovie(id="tt0133093", title="The Matrix", year=None)
+    client = DummyClient([movie_info])
+    renamer = MovieRenamer(client, console=DummyConsole(["1"]))
+
+    results = renamer.process_directory(movie.parent, dry_run=True, search_limit=5)
+
+    assert len(results) == 1
+    assert results[0].proposed_filename == "The Matrix.mkv"


### PR DESCRIPTION
## Summary
- add reusable rename format specifications and expose multiple presets for file naming
- allow selecting the filename format from the CLI and GUI, defaulting to "Title (Year)"
- expand unit tests to cover the new formatting options and missing year handling

## Testing
- pytest

------
