### PR TITLE
Update rename formats for TV shows

### DIFF
--- a/deebee/imdb_client.py
+++ b/deebee/imdb_client.py
@@ -23,7 +23,8 @@ class IMDBMovie:
 
     id: str
     title: str
-    year: Optional[str]
+    year: Optional[str] = None
+    episode_title: Optional[str] = None
 
     @classmethod
     def from_dict(cls, payload: dict) -> "IMDBMovie":
@@ -42,10 +43,23 @@ class IMDBMovie:
         )
         year = str(year_value) if year_value else None
 
+        episode_title = (
+            (payload.get("episodeTitle") or {}).get("text")
+            if isinstance(payload.get("episodeTitle"), dict)
+            else payload.get("episodeTitle")
+        )
+        if not episode_title:
+            episode = payload.get("episodeTitle") or payload.get("episode")
+            if isinstance(episode, dict):
+                episode_title = episode.get("title") or episode.get("name")
+            elif isinstance(episode, str):
+                episode_title = episode
+
         return cls(
             id=payload.get("id", ""),
             title=title,
             year=year,
+            episode_title=episode_title if episode_title else None,
         )
 
     def display_text(self) -> str:

--- a/deebee/tvdb_client.py
+++ b/deebee/tvdb_client.py
@@ -62,6 +62,7 @@ class TVDBSeries:
     id: int
     title: str
     year: Optional[str]
+    episode_title: Optional[str] = None
 
     @classmethod
     def from_dict(cls, payload: Any) -> "TVDBSeries":


### PR DESCRIPTION
## Summary
- switch rename format presets to TV show friendly variants and default to "TV Show Name - Episode Name - S##E##"
- capture optional episode titles from metadata clients so episode names can be included in filenames
- expand unit tests to cover the new formatting behaviour for episodes

## Testing
- pytest

------
