### PR TITLE
Ignore year tokens when searching for TV episodes

### DIFF
--- a/deebee/renamer.py
+++ b/deebee/renamer.py
@@ -33,6 +33,7 @@ class MediaSearchClient(Protocol[TMetadata]):
         """Return search results for the provided query."""
 
 INVALID_FILENAME_CHARS = re.compile(r"[^A-Za-z0-9_.\- ]+")
+YEAR_TOKEN_PATTERN = re.compile(r"\b(19|20)\d{2}\b")
 SEASON_EPISODE_PATTERNS = (
     re.compile(r"(?i)\bS(?P<season>\d{1,3})[ ._-]*E(?P<episode>\d{1,3})\b"),
     re.compile(r"(?i)\b(?P<season>\d{1,3})x(?P<episode>\d{1,3})\b"),
@@ -350,6 +351,11 @@ class MovieRenamer(Generic[TMetadata]):
         base = INVALID_FILENAME_CHARS.sub(" ", base)
         base = re.sub(r"\s+", " ", base)
         base = _strip_trailing_release_tokens(base)
+
+        if season_number is not None or episode_number is not None:
+            base = YEAR_TOKEN_PATTERN.sub(" ", base)
+            base = re.sub(r"\s+", " ", base)
+
         query = base.strip()
         logger.debug("Normalized search query for %s: '%s'", path.name, query)
 

--- a/tests/test_renamer.py
+++ b/tests/test_renamer.py
@@ -61,6 +61,20 @@ def test_prepare_search_extracts_episode_numbers(tv_episode: Path) -> None:
     assert search_info.episode_number == 3
 
 
+def test_prepare_search_ignores_year_for_tv_episode(tmp_path: Path) -> None:
+    episode_path = tmp_path / "Doctor.Who.2005.S01E01.mkv"
+    episode_path.write_text("dummy")
+
+    client = DummyClient([])
+    renamer = MovieRenamer(client, console=DummyConsole())
+
+    search_info = renamer._prepare_search(episode_path)
+
+    assert search_info.query == "Doctor Who"
+    assert search_info.season_number == 1
+    assert search_info.episode_number == 1
+
+
 def test_process_directory_dry_run(movie: Path) -> None:
     movie_info = IMDBMovie(id="tt0133093", title="The Matrix", year="1999")
     client = DummyClient([movie_info])


### PR DESCRIPTION
## Summary
- strip 19xx/20xx year tokens from TV episode search queries when season or episode numbers are detected
- add coverage that ensures episode filenames including a year still produce the expected search query

## Testing
- pytest

------
