### PR TITLE
Respect selected TV rename format

### DIFF
--- a/deebee/renamer.py
+++ b/deebee/renamer.py
@@ -255,8 +255,12 @@ class MovieCandidate(Generic[TMetadata]):
             episode_number=self.episode_number,
         )
         filename = self.format_spec.build_name(context)
-        if self.season_number is not None and self.episode_number is not None:
-            # Ensure season/episode markers are present for formats that omit them.
+        if (
+            self.season_number is not None
+            and self.episode_number is not None
+            and not self.format_spec.supports_mode("tv")
+        ):
+            # Ensure season/episode markers are present for movie formats that omit them.
             if f"S{self.season_number:02d}E{self.episode_number:02d}" not in filename:
                 filename = f"{filename} S{self.season_number:02d}E{self.episode_number:02d}"
         return f"{filename}{self.original_path.suffix}"

--- a/tests/test_renamer.py
+++ b/tests/test_renamer.py
@@ -170,3 +170,45 @@ def test_show_numbers_format_appends_marker(tv_episode: Path) -> None:
 
     assert len(results) == 1
     assert results[0].proposed_filename == "The Expanse - S02E03.mkv"
+
+
+def test_show_episode_format_respects_selection(tv_episode: Path) -> None:
+    episode_metadata = IMDBMovie(
+        id="tt999",
+        title="The Expanse",
+        year="2015",
+        episode_title="Static",
+    )
+    client = DummyClient([episode_metadata])
+    renamer = MovieRenamer(
+        client,
+        console=DummyConsole(["1"]),
+        rename_format="show_episode",
+        media_mode="tv",
+    )
+
+    results = renamer.process_directory(tv_episode.parent, dry_run=True, search_limit=5)
+
+    assert len(results) == 1
+    assert results[0].proposed_filename == "The Expanse - Static.mkv"
+
+
+def test_show_only_format_respects_selection(tv_episode: Path) -> None:
+    episode_metadata = IMDBMovie(
+        id="tt999",
+        title="The Expanse",
+        year="2015",
+        episode_title="Static",
+    )
+    client = DummyClient([episode_metadata])
+    renamer = MovieRenamer(
+        client,
+        console=DummyConsole(["1"]),
+        rename_format="show_only",
+        media_mode="tv",
+    )
+
+    results = renamer.process_directory(tv_episode.parent, dry_run=True, search_limit=5)
+
+    assert len(results) == 1
+    assert results[0].proposed_filename == "The Expanse.mkv"


### PR DESCRIPTION
## Summary
- prevent forced season/episode markers when using TV-specific filename formats
- add regression tests to ensure TV rename options produce the expected filenames

## Testing
- pytest

------
