### PR TITLE
Split media renaming logic into dedicated movie and TV modules

### DIFF
--- a/deebee/cli.py
+++ b/deebee/cli.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from rich.console import Console
 
 from .imdb_client import IMDBClient
-from .renamer import DEFAULT_RENAME_FORMAT_KEY, MovieRenamer
+from .movie_renamer import DEFAULT_MOVIE_RENAME_FORMAT_KEY, MovieRenamer
 
 
 LOG_LEVEL_CHOICES = ["critical", "error", "warning", "info", "debug"]
@@ -34,13 +34,13 @@ def build_parser() -> argparse.ArgumentParser:
         default=10,
         help="Maximum number of IMDB results to present",
     )
-    formats = MovieRenamer.available_formats(mode="movie")
+    formats = MovieRenamer.available_formats()
     format_descriptions = ", ".join(f"{spec.key}: {spec.label}" for spec in formats)
     parser.add_argument(
         "--format",
         dest="rename_format",
         choices=[spec.key for spec in formats],
-        default=DEFAULT_RENAME_FORMAT_KEY,
+        default=DEFAULT_MOVIE_RENAME_FORMAT_KEY,
         help=f"Filename format to use. Available options: {format_descriptions}",
     )
     parser.add_argument(
@@ -71,7 +71,6 @@ def main(argv: list[str] | None = None) -> int:
         imdb_client,
         console,
         rename_format=args.rename_format,
-        media_mode="movie",
     )
 
     directory = Path(args.path)

--- a/deebee/movie_renamer.py
+++ b/deebee/movie_renamer.py
@@ -1,0 +1,59 @@
+"""Movie-specific renaming logic."""
+from __future__ import annotations
+
+from typing import Optional, TypeVar
+
+from rich.console import Console
+
+from .rename_common import (
+    BaseRenamer,
+    MediaMetadata,
+    MediaSearchClient,
+    RenameContext,
+    RenameFormatSpec,
+)
+
+
+TMetadata = TypeVar("TMetadata", bound=MediaMetadata)
+
+
+def _format_movie_title_with_year(context: RenameContext) -> str:
+    if context.year:
+        return f"{context.series_title} ({context.year})"
+    return context.series_title
+
+
+def _format_movie_title(context: RenameContext) -> str:
+    return context.series_title
+
+
+MOVIE_RENAME_FORMATS: dict[str, RenameFormatSpec] = {
+    "movie_title": RenameFormatSpec(
+        "movie_title",
+        "Movie Title",
+        _format_movie_title,
+    ),
+    "movie_title_year": RenameFormatSpec(
+        "movie_title_year",
+        "Movie Title (Year)",
+        _format_movie_title_with_year,
+    ),
+}
+
+DEFAULT_MOVIE_RENAME_FORMAT_KEY = "movie_title"
+
+
+class MovieRenamer(BaseRenamer[TMetadata]):
+    """Renamer dedicated to movie files."""
+
+    RENAME_FORMATS = MOVIE_RENAME_FORMATS
+    DEFAULT_RENAME_FORMAT_KEY = DEFAULT_MOVIE_RENAME_FORMAT_KEY
+
+    def __init__(
+        self,
+        media_client: MediaSearchClient[TMetadata],
+        console: Optional[Console] = None,
+        *,
+        rename_format: Optional[str] = None,
+    ) -> None:
+        super().__init__(media_client, console=console, rename_format=rename_format)

--- a/deebee/tv_renamer.py
+++ b/deebee/tv_renamer.py
@@ -1,0 +1,87 @@
+"""TV-specific renaming logic."""
+from __future__ import annotations
+
+from typing import Optional, TypeVar
+
+from rich.console import Console
+
+from .rename_common import (
+    BaseRenamer,
+    MediaMetadata,
+    MediaSearchClient,
+    RenameContext,
+    RenameFormatSpec,
+)
+
+
+TMetadata = TypeVar("TMetadata", bound=MediaMetadata)
+
+
+def _format_show_episode_with_numbers(context: RenameContext) -> str:
+    parts: list[str] = [context.series_title]
+    if context.episode_title:
+        parts.append(context.episode_title)
+    season = context.season_number
+    episode = context.episode_number
+    if season is not None and episode is not None:
+        parts.append(f"S{season:02d}E{episode:02d}")
+    return " - ".join(part for part in parts if part)
+
+
+def _format_show_with_numbers(context: RenameContext) -> str:
+    season = context.season_number
+    episode = context.episode_number
+    suffix = f" - S{season:02d}E{episode:02d}" if season is not None and episode is not None else ""
+    return f"{context.series_title}{suffix}"
+
+
+def _format_show_episode(context: RenameContext) -> str:
+    if context.episode_title:
+        return f"{context.series_title} - {context.episode_title}"
+    return context.series_title
+
+
+def _format_show_only(context: RenameContext) -> str:
+    return context.series_title
+
+
+TV_RENAME_FORMATS: dict[str, RenameFormatSpec] = {
+    "show_episode_numbers": RenameFormatSpec(
+        "show_episode_numbers",
+        "TV Show Name - Episode Name - S##E##",
+        _format_show_episode_with_numbers,
+    ),
+    "show_numbers": RenameFormatSpec(
+        "show_numbers",
+        "TV Show Name - S##E##",
+        _format_show_with_numbers,
+    ),
+    "show_episode": RenameFormatSpec(
+        "show_episode",
+        "TV Show Name - Episode Name",
+        _format_show_episode,
+    ),
+    "show_only": RenameFormatSpec(
+        "show_only",
+        "TV Show Name",
+        _format_show_only,
+    ),
+}
+
+DEFAULT_TV_RENAME_FORMAT_KEY = "show_episode_numbers"
+
+
+class TVRenamer(BaseRenamer[TMetadata]):
+    """Renamer dedicated to TV episode files."""
+
+    RENAME_FORMATS = TV_RENAME_FORMATS
+    DEFAULT_RENAME_FORMAT_KEY = DEFAULT_TV_RENAME_FORMAT_KEY
+
+    def __init__(
+        self,
+        media_client: MediaSearchClient[TMetadata],
+        console: Optional[Console] = None,
+        *,
+        rename_format: Optional[str] = None,
+    ) -> None:
+        super().__init__(media_client, console=console, rename_format=rename_format)

--- a/tests/test_renamer.py
+++ b/tests/test_renamer.py
@@ -4,11 +4,8 @@ from typing import List
 import pytest
 
 from deebee.imdb_client import IMDBMovie
-from deebee.renamer import (
-    DEFAULT_RENAME_FORMAT_KEY,
-    DEFAULT_TV_RENAME_FORMAT_KEY,
-    MovieRenamer,
-)
+from deebee.movie_renamer import DEFAULT_MOVIE_RENAME_FORMAT_KEY, MovieRenamer
+from deebee.tv_renamer import DEFAULT_TV_RENAME_FORMAT_KEY, TVRenamer
 
 
 class DummyConsole:
@@ -58,7 +55,7 @@ def test_guess_search_query(movie: Path) -> None:
 
 def test_prepare_search_extracts_episode_numbers(tv_episode: Path) -> None:
     client = DummyClient([])
-    renamer = MovieRenamer(client, console=DummyConsole())
+    renamer = TVRenamer(client, console=DummyConsole())
     search_info = renamer._prepare_search(tv_episode)
     assert search_info.query == "The Expanse"
     assert search_info.season_number == 2
@@ -70,7 +67,7 @@ def test_prepare_search_ignores_year_for_tv_episode(tmp_path: Path) -> None:
     episode_path.write_text("dummy")
 
     client = DummyClient([])
-    renamer = MovieRenamer(client, console=DummyConsole())
+    renamer = TVRenamer(client, console=DummyConsole())
 
     search_info = renamer._prepare_search(episode_path)
 
@@ -98,7 +95,7 @@ def test_process_directory_dry_run(movie: Path) -> None:
 @pytest.mark.parametrize(
     "format_key,expected",
     [
-        (DEFAULT_RENAME_FORMAT_KEY, "The Matrix.mkv"),
+        (DEFAULT_MOVIE_RENAME_FORMAT_KEY, "The Matrix.mkv"),
         ("movie_title_year", "The Matrix (1999).mkv"),
     ],
 )
@@ -138,10 +135,9 @@ def test_process_directory_includes_episode_numbers(tv_episode: Path) -> None:
         episode_title="Static",
     )
     client = DummyClient([episode_metadata])
-    renamer = MovieRenamer(
+    renamer = TVRenamer(
         client,
         console=DummyConsole(["1"]),
-        media_mode="tv",
     )
 
     results = renamer.process_directory(tv_episode.parent, dry_run=True, search_limit=5)
@@ -159,11 +155,10 @@ def test_show_numbers_format_appends_marker(tv_episode: Path) -> None:
         episode_title="Static",
     )
     client = DummyClient([episode_metadata])
-    renamer = MovieRenamer(
+    renamer = TVRenamer(
         client,
         console=DummyConsole(["1"]),
         rename_format="show_numbers",
-        media_mode="tv",
     )
 
     results = renamer.process_directory(tv_episode.parent, dry_run=True, search_limit=5)
@@ -180,11 +175,10 @@ def test_show_episode_format_respects_selection(tv_episode: Path) -> None:
         episode_title="Static",
     )
     client = DummyClient([episode_metadata])
-    renamer = MovieRenamer(
+    renamer = TVRenamer(
         client,
         console=DummyConsole(["1"]),
         rename_format="show_episode",
-        media_mode="tv",
     )
 
     results = renamer.process_directory(tv_episode.parent, dry_run=True, search_limit=5)
@@ -201,11 +195,10 @@ def test_show_only_format_respects_selection(tv_episode: Path) -> None:
         episode_title="Static",
     )
     client = DummyClient([episode_metadata])
-    renamer = MovieRenamer(
+    renamer = TVRenamer(
         client,
         console=DummyConsole(["1"]),
         rename_format="show_only",
-        media_mode="tv",
     )
 
     results = renamer.process_directory(tv_episode.parent, dry_run=True, search_limit=5)


### PR DESCRIPTION
## Summary
- extract shared renaming primitives into `rename_common` and add dedicated `movie_renamer` and `tv_renamer` modules
- update the CLI and Tkinter GUI to work with the new movie/TV-specific renamers and expose accurate format options
- refresh unit tests to cover both renamers independently

## Testing
- pytest

------
