### PR TITLE
Support season type when looking up TVDB episodes

### DIFF
--- a/deebee/tvdb_client.py
+++ b/deebee/tvdb_client.py
@@ -505,6 +505,90 @@ class TheTVDBClient:
             }),
         ]
 
+        season_type_options = (
+            "official",
+            "default",
+            "aired",
+            "standard",
+            "dvd",
+            "absolute",
+        )
+
+        for season_type in season_type_options:
+            attempts.extend(
+                [
+                    ((series_id, season_type, season_number, episode_number), {}),
+                    (
+                        (series_id,),
+                        {
+                            "season": season_number,
+                            "episode": episode_number,
+                            "season_type": season_type,
+                        },
+                    ),
+                    (
+                        (series_id,),
+                        {
+                            "season": season_number,
+                            "episode": episode_number,
+                            "seasonType": season_type,
+                        },
+                    ),
+                    (
+                        (series_id,),
+                        {
+                            "seasonNumber": season_number,
+                            "episodeNumber": episode_number,
+                            "season_type": season_type,
+                        },
+                    ),
+                    (
+                        (series_id,),
+                        {
+                            "seasonNumber": season_number,
+                            "episodeNumber": episode_number,
+                            "seasonType": season_type,
+                        },
+                    ),
+                    (
+                        (),
+                        {
+                            "series": series_id,
+                            "season": season_number,
+                            "episode": episode_number,
+                            "season_type": season_type,
+                        },
+                    ),
+                    (
+                        (),
+                        {
+                            "series": series_id,
+                            "season": season_number,
+                            "episode": episode_number,
+                            "seasonType": season_type,
+                        },
+                    ),
+                    (
+                        (),
+                        {
+                            "seriesId": series_id,
+                            "seasonNumber": season_number,
+                            "episodeNumber": episode_number,
+                            "season_type": season_type,
+                        },
+                    ),
+                    (
+                        (),
+                        {
+                            "seriesId": series_id,
+                            "seasonNumber": season_number,
+                            "episodeNumber": episode_number,
+                            "seasonType": season_type,
+                        },
+                    ),
+                ]
+            )
+
         for args, kwargs in attempts:
             filtered_kwargs = {key: value for key, value in kwargs.items() if value is not None}
             try:

--- a/tests/test_tvdb_client.py
+++ b/tests/test_tvdb_client.py
@@ -1,0 +1,60 @@
+"""Tests for TheTVDB client helpers."""
+from __future__ import annotations
+
+from typing import Any
+
+from deebee.tvdb_client import TheTVDBClient
+
+
+def test_invoke_episode_lookup_supports_season_type_argument() -> None:
+    """Episode lookups should support callables that require a season type."""
+
+    client = object.__new__(TheTVDBClient)
+    captured: dict[str, Any] = {}
+
+    def sentinel(*args: Any, **kwargs: Any) -> dict[str, str]:
+        if len(args) == 4:
+            series_id, season_type, season_number, episode_number = args
+            if season_type == "official":
+                captured.update(
+                    {
+                        "series_id": series_id,
+                        "season_type": season_type,
+                        "season_number": season_number,
+                        "episode_number": episode_number,
+                        "kwargs": kwargs,
+                    }
+                )
+                return {"name": "Episode"}
+        raise TypeError(f"Unexpected invocation: args={args!r}, kwargs={kwargs!r}")
+
+    result = client._invoke_episode_lookup(sentinel, 1, 2, 3)
+
+    assert result == {"name": "Episode"}
+    assert captured == {
+        "series_id": 1,
+        "season_type": "official",
+        "season_number": 2,
+        "episode_number": 3,
+        "kwargs": {},
+    }
+
+
+def test_invoke_episode_lookup_tries_alternative_signatures() -> None:
+    """The helper should continue trying combinations until one succeeds."""
+
+    client = object.__new__(TheTVDBClient)
+    attempts: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    def sentinel(*args: Any, **kwargs: Any) -> dict[str, str]:
+        attempts.append((args, kwargs))
+        if kwargs.get("seasonType") == "official":
+            return {"name": "Episode"}
+        raise TypeError("Unsupported signature")
+
+    result = client._invoke_episode_lookup(sentinel, 4, 5, 6)
+
+    assert result == {"name": "Episode"}
+    # Ensure at least one attempt used the camelCase seasonType keyword.
+    assert any("seasonType" in kwargs for _, kwargs in attempts)
+


### PR DESCRIPTION
## Summary
- allow the TVDB episode lookup helper to try call signatures that require a season type argument
- add unit tests exercising the new combinations for the helper

## Testing
- pytest

------
